### PR TITLE
ci: add CodeQL Advanced workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+# CodeQL Advanced — MotionOps
+# Static analysis for JS/TS, Python (worker-cv) and GitHub Actions workflows.
+# Triggered on PRs (push to main is blocked by the "main protection" ruleset)
+# and weekly on Tuesday morning.
+
+name: "CodeQL"
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '45 6 * * 2'
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds CodeQL static analysis for actions, javascript-typescript and python (worker-cv).

- pull_request-only trigger (push to main is blocked by the main protection ruleset)
- Weekly schedule on Tuesday 06:45 UTC
- security-extended query suite
- concurrency group cancels obsolete PR runs
- timeout-minutes: 360 (CodeQL recommended)