### PR TITLE
ci(dependabot): exclude typescript and eslint major bumps from tooling group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,15 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # TypeScript 6.0 introduit des changements de résolution de modules
+      # (ex: side-effect imports CSS) qui cassent le typecheck. Bump majeur
+      # à reviewer manuellement (cf PR #32 fermée).
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # ESLint 10 a un nouveau format de config qui peut casser la CI lint.
+      # Bump majeur à reviewer manuellement (cf PR #32 fermée).
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------
   # 2) Python — worker computer vision (apps/worker-cv)


### PR DESCRIPTION
## Contexte

PR #32 (`chore(deps-dev): bump the tooling group across 1 directory with 2 updates`) a été fermée car elle bumpait simultanément :
- `typescript` 5.9.3 -> 6.0.3 (majeur)
- `eslint` 9.39.4 -> 10.2.1 (majeur)

Ces deux majeures étaient agrégées dans le groupe `tooling` de Dependabot, ce qui rendait impossible de garder l'une et rejeter l'autre.

## Symptôme

CI typecheck cassée sur `apps/web` :
```
src/app/layout.tsx(2,8): error TS2882: Cannot find module or type declarations for side-effect import of './globals.css'.
```

TypeScript 6.0 a durci la résolution des side-effect imports avec `moduleResolution: bundler` ; les imports CSS sans déclaration ambiente sont désormais flaggés.

## Fix

Aligne `typescript` et `eslint` sur le même pattern d'ignore que `react` / `react-dom` : les majeures sont exclues du groupe `tooling` et devront être proposées par Dependabot dans une PR dédiée, reviewable manuellement (avec migration codemods si besoin).

Les bumps minor/patch de ces packages restent groupés normalement.

## Impact

- Aucun changement de code applicatif.
- Aucun impact sur la CI actuelle (TS 5.9 / ESLint 9 inchangés).
- Prévient la réouverture automatique d'une PR équivalente à #32 lundi prochain.

## Vérification

- [x] `git diff` minimal (9 lignes ajoutées dans `.github/dependabot.yml`).
- [x] Aucun fichier code touché, donc pas de regression typecheck/lint possible.
- [ ] Lundi suivant le merge : confirmer qu'aucune nouvelle PR Dependabot ne propose un bump majeur de typescript ou eslint.