### PR TITLE
ci(repo): bump CI actions to setup-node@v6 and action-setup@v6

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Apply labels from .github/labeler.yml
-        uses: actions/labeler@8558a7337f8f1b0c5b8f7347f0cdd2bdc5f306a7
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -32,8 +32,8 @@ jobs:
     needs: unit
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v3
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm


### PR DESCRIPTION
Consolidates Dependabot bumps #3 (actions/setup-node v4→v6) and #5 (pnpm/action-setup v3→v6) into a single PR.

## Changes
- `actions/setup-node` v4 → v6 in lint, typecheck, test workflows
- `pnpm/action-setup` v3 → v6 in lint, typecheck, test workflows

## Compatibility check
- setup-node v5 introduced auto package manager caching. We override with explicit `cache: pnpm` so behavior is unchanged.
- setup-node v6 limits auto caching to npm only. Explicit `cache: pnpm` keeps pnpm caching active.
- pnpm/action-setup v6 adds pnpm 11 support but defers to `packageManager` field in package.json (currently pnpm@10.33.0).

## Validation
CI on this branch will run all three workflows against the new action versions.