### PR TITLE
chore(worker): bump pydantic and python-socketio to latest

### DIFF
--- a/apps/worker-cv/requirements.txt
+++ b/apps/worker-cv/requirements.txt
@@ -1,9 +1,9 @@
 opencv-python-headless>=4.13.0.92
 ultralytics>=8.3.0
-python-socketio[asyncio]>=5.12.0
+python-socketio[asyncio]>=5.16.1
 fastapi>=0.136.1
 uvicorn[standard]>=0.46.0
-pydantic>=2.10.0
+pydantic>=2.13.3
 pydantic-settings>=2.14.0
 httpx>=0.28.0
 Pillow>=11.0.0


### PR DESCRIPTION
Consolidates Dependabot PRs #7 (pydantic >=2.13.3) and #8 (python-socketio >=5.16.1) into a single requirements.txt update.

## Changes
- `pydantic>=2.10.0` → `pydantic>=2.13.3` (non-breaking minor: AttributeError fix in from_attributes)
- `python-socketio[asyncio]>=5.12.0` → `>=5.16.1` (non-breaking: JSON module config, free-threading CI)

Both are pinned-floor bumps; existing installations satisfying the floor automatically pick up the latest 2.x / 5.x compatible release.