### PR TITLE
fix(repo): exclude apps/docs from pnpm workspace

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,8 @@
 packages:
   - "apps/*"
   - "packages/*"
+  # apps/docs (Nextra v2 + Next 14) is excluded from the workspace until it
+  # is migrated to Nextra v4 + Next 16 — keeping it in the workspace pins
+  # vulnerable next@14 transitives in the root lockfile and blocks dep-review.
+  - "!apps/docs"
 approveBuilds: true


### PR DESCRIPTION
## Problem
`pnpm install --frozen-lockfile` was failing on main because apps/docs (Nextra v2 + Next 14) requires lockfile entries that conflict with the rest of the monorepo:
- Anthony previously regenerated the lockfile without docs (commit 60dfefc) to drop next@14 transitives
- The Next 16 merge (#42) ran a fresh install which reintroduced apps/docs entries with stale specifiers
- dep-review now flags 5 GHSA advisories on next@14 (no patched 14.x release exists)

## Fix
Add `!apps/docs` to `pnpm-workspace.yaml` so the docs site is decoupled from the shared lockfile until it can be migrated to Nextra v4 + Next 16. apps/docs can still be developed in isolation via `cd apps/docs && pnpm install`.

## Follow-up
Migrating apps/docs to Nextra v4 + Next 16 is a tracked manual sprint (Nextra v2→v4 has breaking theme/MDX changes).